### PR TITLE
Remove obsolete APIs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,11 +24,7 @@ The currency can be changed in the [config file](config.yml) .
 The script:
 
 - retrieves balance data from an ETH2 beacon node, using the
- parameters specified in [config.yml](config.yml) .
- If you're running a Prysm beacon node, make sure
- to set the `PRYSM_API` config option to True.
- If you're running a Nimbus beacon node, make sure
- to set the `NIMBUS_API` config option to True.
+ parameters specified in [config.yml](config.yml).
 - pulls corresponding price data from CoinGecko
 - combines and writes these into a CSV file called
  `rewards_{VALIDATOR_INDEX}_{ETH2_ADDRESS}.csv`

--- a/README.MD
+++ b/README.MD
@@ -28,15 +28,3 @@ The script:
 - pulls corresponding price data from CoinGecko
 - combines and writes these into a CSV file called
  `rewards_{VALIDATOR_INDEX}_{ETH2_ADDRESS}.csv`
-
-## Tested with
-
-- [x] Lighthouse v1.1.0
-- [x] Prysm v1.2.1 (set `PRYSM_API` to True in the config file)
-- [x] Teku v21.1.1
-  - Teku prunes chain data by default - if you're getting 404 errors,
-  make sure you are running Teku in
-  [archive](https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#data-storage-mode)
-  mode to be able to retrieve balances for finalized epochs (`--data-storage-mode=archive`)
-- [x] Nimbus v1.0.7 (set `NIMBUS_API` to True in the config file)
-

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,4 @@
+ 
 # Enter your validator's indexes, their ETH2 addresses (public keys)
 # or the ETH1 addresses that you deposited from.
 # You don't have to enter all of these, just remove (or comment out using #)
@@ -32,12 +33,6 @@ BEACON_NODE:
   # Enter the HTTP/RPC port of the beacon node
   # Defaults - Lighthouse 5052, Prysm 3500, Teku 5051, Nimbus 9190
   PORT: 5052
-  # Set this to True if running a Prysm beacon node (it uses a different API)
-  # Should be set to False for Lighthouse, Teku, Nimbus
-  PRYSM_API: False
-  # Set this to True if running a Nimbus beacon node (it uses a different API)
-  # Should be set to False for Lighthouse, Prysm, Teku
-  NIMBUS_API: False
   # The amount of concurrent requests to make to the beacon node
   # (making more than 1 request at once makes things faster, but is
   # also more demanding on your beacon node)

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,3 @@
- 
 # Enter your validator's indexes, their ETH2 addresses (public keys)
 # or the ETH1 addresses that you deposited from.
 # You don't have to enter all of these, just remove (or comment out using #)


### PR DESCRIPTION
Prysm and Nimbus no longer use unique APIs. Each validator client now uses a standardized API: https://ethereum.github.io/beacon-APIs/

This PR removes the non-standard API usages and unifies everything. Config.yml and README are also updated.

Tested with Nimbus [v1.7.0](https://github.com/status-im/nimbus-eth2/releases/tag/v1.7.0)